### PR TITLE
Frends.Kafka.Consume not able to consume - fixed by adding partition setting

### DIFF
--- a/Frends.Kafka.Consume/CHANGELOG.md
+++ b/Frends.Kafka.Consume/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2023-11-27
+### Added
+- Added a partition as input parameter to the task.
+
 ## [1.0.1] - 2023-04-17
 ### Fixed
 - Changed Task to set ssl.SslCaCertificateStores only if it's set as parameter.

--- a/Frends.Kafka.Consume/CHANGELOG.md
+++ b/Frends.Kafka.Consume/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.2] - 2023-11-27
+## [1.1.0] - 2023-11-27
 ### Added
 - Added a partition as input parameter to the task.
 

--- a/Frends.Kafka.Consume/Frends.Kafka.Consume/Definitions/Input.cs
+++ b/Frends.Kafka.Consume/Frends.Kafka.Consume/Definitions/Input.cs
@@ -40,4 +40,10 @@ public class Input
     /// <example>60000</example>
     [DefaultValue(0)]
     public int Timeout { get; set; }
+
+    /// <summary>
+    /// Set Kafka partition.
+    /// </summary>
+    /// <example>10</example>
+    public int Partition { get; set; }
 }

--- a/Frends.Kafka.Consume/Frends.Kafka.Consume/Frends.Kafka.Consume.csproj
+++ b/Frends.Kafka.Consume/Frends.Kafka.Consume/Frends.Kafka.Consume.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.0.1</Version>
+	<Version>1.0.2</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.Kafka.Consume/Frends.Kafka.Consume/Frends.Kafka.Consume.csproj
+++ b/Frends.Kafka.Consume/Frends.Kafka.Consume/Frends.Kafka.Consume.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.0.2</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
The client had a problem where messages couldn't be consumed because of different partition settings. This was fixed by adding a partition as an input and by updating message handling.